### PR TITLE
Feature/fix instance storage failover

### DIFF
--- a/addon/adapters/local.js
+++ b/addon/adapters/local.js
@@ -1,4 +1,7 @@
 import AbstractAdapter from './abstract';
+import Ember from 'ember';
+
+const {computed} = Ember;
 
 /*global window*/
 
@@ -14,5 +17,7 @@ import AbstractAdapter from './abstract';
  */
 
 export default AbstractAdapter.extend({
-  storage: window.localStorage
+  storage: computed(function () {
+    return window.localStorage;
+  }).readOnly()
 });

--- a/addon/adapters/session.js
+++ b/addon/adapters/session.js
@@ -1,5 +1,7 @@
 import AbstractAdapter from './abstract';
 
+const {computed} = Ember;
+
 /*global window*/
 
 /**
@@ -14,5 +16,7 @@ import AbstractAdapter from './abstract';
  */
 
 export default AbstractAdapter.extend({
-  storage: window.sessionStorage
+  storage: computed(function () {
+    return window.sessionStorage;
+  }).readOnly()
 });

--- a/addon/initializers/inject-storagekit.js
+++ b/addon/initializers/inject-storagekit.js
@@ -1,34 +1,17 @@
-import InstanceStorageService from 'ember-cli-storagekit/services/instance-storage';
-import LocalStorageService from 'ember-cli-storagekit/services/local-storage';
-import SessionStorageService from 'ember-cli-storagekit/services/session-storage';
-import StorageSupportUtility from '../utilities/storage-support';
 
-export default function () {
+export default function() {
   // keep backwards compatibility with previous versions having 2 arguments (container, application)
   let application = arguments[1] || arguments[0];
 
-  // service registrations
-  const hasLocalStorageSupport = StorageSupportUtility.has('localStorage');
-  const LocalStorageFactory = hasLocalStorageSupport ? LocalStorageService : InstanceStorageService;
-
-  application.register('storagekit/service:local-storage', LocalStorageFactory);
-
-  const hasSessionStorageSupport = StorageSupportUtility.has('sessionStorage');
-  const SessionStorageFactory = hasSessionStorageSupport ? SessionStorageService : InstanceStorageService;
-
-  application.register('storagekit/service:session-storage', SessionStorageFactory);
-
-  application.register('storagekit/service:instance-storage', InstanceStorageService);
+  //adapter injections
+  application.inject('storagekit/service:local-storage', 'adapter', 'storagekit/adapter:local');
+  application.inject('storagekit/service:session-storage', 'adapter', 'storagekit/adapter:session');
+  application.inject('storagekit/service:instance-storage', 'adapter', 'storagekit/adapter:instance');
 
   // service injections
   application.inject('storagekit/service:storage', 'local', 'storagekit/service:local-storage');
   application.inject('storagekit/service:storage', 'session', 'storagekit/service:session-storage');
   application.inject('storagekit/service:storage', 'instance', 'storagekit/service:instance-storage');
-
-  // adapter injections
-  application.inject('storagekit/service:instance-storage', 'adapter', 'storagekit/adapter:instance');
-  application.inject('storagekit/service:local-storage', 'adapter', 'storagekit/adapter:local');
-  application.inject('storagekit/service:session-storage', 'adapter', 'storagekit/adapter:session');
 
   // serializer injections
   application.inject('storagekit/adapter', 'serializer', 'storagekit/serializer:json');

--- a/addon/instance-initializers/inject-storagekit.js
+++ b/addon/instance-initializers/inject-storagekit.js
@@ -1,0 +1,15 @@
+import InstanceStorageAdapter from 'ember-cli-storagekit/adapters/instance';
+import StorageSupportUtility from '../utilities/storage-support';
+
+export default function(application) {
+  // fallback to instance storage when necessary. Need to do the check here in order to be certain
+  // that we are in the browser, since its possibles for initializers may fire during the fastboot process..
+
+  if(!StorageSupportUtility.has('localStorage')) {
+    application.register('storagekit/adapter:local', InstanceStorageAdapter);
+  }
+
+  if(!StorageSupportUtility.has('sessionStorage')) {
+    application.register('storagekit/adapter:session', InstanceStorageAdapter);
+  }
+}

--- a/addon/utilities/storage-support.js
+++ b/addon/utilities/storage-support.js
@@ -31,15 +31,23 @@ export default Ember.Namespace.create({
    * @public
    */
   has(type) {
-    const _global = this.get('global');
+    let _global = this.get('global');
+
     try {
-      // credit: https://gist.github.com/paulirish/5558557
-      const randomMD5 = '946d4feb0eac1298f72834168f4dffb2';
+      const supports = type in _global && _global[type] !== null;
 
-      _global[type].setItem(randomMD5, randomMD5);
-      _global[type].getItem(randomMD5);
+      const randomHash = '946d4feb0eac1298f72834168f4dffb2';
 
-      return true;
+      if(supports) {
+        // Firefox will still throw an error even if localStorage is present, but the user does not allow storage.
+        // We make a call to a random getItem in order to throw the error in a controller manner, and return false.
+        _global[type].getItem(randomHash);
+
+        // Safari will only throw on setItem() in private mode - see: http://gist.github.com/paulirish/5558557
+        _global[type].setItem(randomHash, randomHash);
+        _global[type].removeItem(randomHash);
+      }
+      return supports;
     } catch (e) {
       return false;
     }

--- a/app/instance-initializers/inject-storagekit.js
+++ b/app/instance-initializers/inject-storagekit.js
@@ -1,0 +1,6 @@
+import initialize from 'ember-cli-storagekit/instance-initializers/inject-storagekit';
+
+export default {
+  name: 'inject-storagekit',
+  initialize: initialize
+};

--- a/tests/unit/initializers/inject-storagekit-test.js
+++ b/tests/unit/initializers/inject-storagekit-test.js
@@ -1,9 +1,4 @@
 import Ember from 'ember';
-//import InjectStoragekitInitializer from 'dummy/initializers/inject-storagekit';
-//import InstanceStorageAdapter from 'ember-cli-storagekit/adapters/instance';
-//import LocalStorageAdapter from 'ember-cli-storagekit/adapters/local';
-//import SessionStorageAdapter from 'ember-cli-storagekit/adapters/session';
-//import StorageSupportUtility from 'ember-cli-storagekit/utilities/storage-support';
 import { module, test } from 'qunit';
 
 /*global sinon*/
@@ -23,46 +18,7 @@ module('Unit | Initializer | inject storagekit', {
   }
 });
 
-test('Registers local/session adapters are present', function(assert) {
+test('your test here', function(assert) {
   assert.expect(0);
-  //
-  //assert.expect(3);
-  //
-  //sandbox.stub(StorageSupportUtility, 'has').returns(true);
-  //
-  //InjectStoragekitInitializer.initialize(application);
-  //
-  //const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/adapter:instance');
-  //
-  //assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageAdapter);
-  //
-  //const RegisteredLocalStorageService = application.resolveRegistration('storagekit/adapter:local');
-  //
-  //assert.strictEqual(RegisteredLocalStorageService, LocalStorageAdapter);
-  //
-  //const RegisteredSessionStorageService = application.resolveRegistration('storagekit/adapter:session');
-  //
-  //assert.strictEqual(RegisteredSessionStorageService, SessionStorageAdapter);
 });
 
-test('Registers local/session adapters are not present', function(assert) {
-  assert.expect(0);
-  //
-  //assert.expect(3);
-  //
-  //sandbox.stub(StorageSupportUtility, 'has').returns(false);
-  //
-  //InjectStoragekitInitializer.initialize(application);
-  //
-  //const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/adapter:instance');
-  //
-  //assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageAdapter);
-  //
-  //const RegisteredLocalStorageService = application.resolveRegistration('storagekit/adapter:local');
-  //
-  //assert.strictEqual(RegisteredLocalStorageService, InstanceStorageAdapter);
-  //
-  //const RegisteredSessionStorageService = application.resolveRegistration('storagekit/adapter:session');
-  //
-  //assert.strictEqual(RegisteredSessionStorageService, InstanceStorageAdapter);
-});

--- a/tests/unit/initializers/inject-storagekit-test.js
+++ b/tests/unit/initializers/inject-storagekit-test.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import InjectStoragekitInitializer from 'dummy/initializers/inject-storagekit';
-import InstanceStorageService from 'ember-cli-storagekit/services/instance-storage';
-import LocalStorageService from 'ember-cli-storagekit/services/local-storage';
-import SessionStorageService from 'ember-cli-storagekit/services/session-storage';
-import StorageSupportUtility from 'ember-cli-storagekit/utilities/storage-support';
+//import InjectStoragekitInitializer from 'dummy/initializers/inject-storagekit';
+//import InstanceStorageAdapter from 'ember-cli-storagekit/adapters/instance';
+//import LocalStorageAdapter from 'ember-cli-storagekit/adapters/local';
+//import SessionStorageAdapter from 'ember-cli-storagekit/adapters/session';
+//import StorageSupportUtility from 'ember-cli-storagekit/utilities/storage-support';
 import { module, test } from 'qunit';
 
 /*global sinon*/
@@ -23,42 +23,46 @@ module('Unit | Initializer | inject storagekit', {
   }
 });
 
-test('Registers local/session storage are present', function(assert) {
-  assert.expect(3);
-
-  sandbox.stub(StorageSupportUtility, 'has').returns(true);
-
-  InjectStoragekitInitializer.initialize(application);
-
-  const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/service:instance-storage');
-
-  assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageService);
-
-  const RegisteredLocalStorageService = application.resolveRegistration('storagekit/service:local-storage');
-
-  assert.strictEqual(RegisteredLocalStorageService, LocalStorageService);
-
-  const RegisteredSessionStorageService = application.resolveRegistration('storagekit/service:session-storage');
-
-  assert.strictEqual(RegisteredSessionStorageService, SessionStorageService);
+test('Registers local/session adapters are present', function(assert) {
+  assert.expect(0);
+  //
+  //assert.expect(3);
+  //
+  //sandbox.stub(StorageSupportUtility, 'has').returns(true);
+  //
+  //InjectStoragekitInitializer.initialize(application);
+  //
+  //const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/adapter:instance');
+  //
+  //assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageAdapter);
+  //
+  //const RegisteredLocalStorageService = application.resolveRegistration('storagekit/adapter:local');
+  //
+  //assert.strictEqual(RegisteredLocalStorageService, LocalStorageAdapter);
+  //
+  //const RegisteredSessionStorageService = application.resolveRegistration('storagekit/adapter:session');
+  //
+  //assert.strictEqual(RegisteredSessionStorageService, SessionStorageAdapter);
 });
 
-test('Registers local/session storage are not present', function(assert) {
-  assert.expect(3);
-
-  sandbox.stub(StorageSupportUtility, 'has').returns(false);
-
-  InjectStoragekitInitializer.initialize(application);
-
-  const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/service:instance-storage');
-
-  assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageService);
-
-  const RegisteredLocalStorageService = application.resolveRegistration('storagekit/service:local-storage');
-
-  assert.strictEqual(RegisteredLocalStorageService, InstanceStorageService);
-
-  const RegisteredSessionStorageService = application.resolveRegistration('storagekit/service:session-storage');
-
-  assert.strictEqual(RegisteredSessionStorageService, InstanceStorageService);
+test('Registers local/session adapters are not present', function(assert) {
+  assert.expect(0);
+  //
+  //assert.expect(3);
+  //
+  //sandbox.stub(StorageSupportUtility, 'has').returns(false);
+  //
+  //InjectStoragekitInitializer.initialize(application);
+  //
+  //const RegisteredInstanceStorageService = application.resolveRegistration('storagekit/adapter:instance');
+  //
+  //assert.strictEqual(RegisteredInstanceStorageService, InstanceStorageAdapter);
+  //
+  //const RegisteredLocalStorageService = application.resolveRegistration('storagekit/adapter:local');
+  //
+  //assert.strictEqual(RegisteredLocalStorageService, InstanceStorageAdapter);
+  //
+  //const RegisteredSessionStorageService = application.resolveRegistration('storagekit/adapter:session');
+  //
+  //assert.strictEqual(RegisteredSessionStorageService, InstanceStorageAdapter);
 });

--- a/tests/unit/instance-initializers/inject-storagekit-test.js
+++ b/tests/unit/instance-initializers/inject-storagekit-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+
+import Ember from 'ember';
+import InjectStoragekitInstanceInitializer from 'dummy/instance-initializers/inject-storagekit';
+import InstanceStorageAdapter from 'ember-cli-storagekit/adapters/instance';
+import StorageSupportUtility from 'ember-cli-storagekit/utilities/storage-support';
+
+import destroyApp from '../../helpers/destroy-app';
+
+/*global sinon*/
+
+let sandbox = sinon.sandbox;
+
+module('Unit | Instance Initializer | inject storagekit', {
+  beforeEach() {
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.appInstance = this.application.buildInstance();
+    });
+  },
+  afterEach() {
+    Ember.run(this.appInstance, 'destroy');
+    destroyApp(this.application);
+
+    sandbox.restore();
+  }
+});
+
+test('Registers local/session adapters are not present', function(assert) {
+  assert.expect(2);
+
+  sandbox.stub(StorageSupportUtility, 'has').returns(false);
+
+  InjectStoragekitInstanceInitializer.initialize(this.appInstance);
+
+  const RegisteredLocalStorageService = this.appInstance.resolveRegistration('storagekit/adapter:local');
+
+  assert.strictEqual(RegisteredLocalStorageService, InstanceStorageAdapter);
+
+  const RegisteredSessionStorageService = this.appInstance.resolveRegistration('storagekit/adapter:session');
+
+  assert.strictEqual(RegisteredSessionStorageService, InstanceStorageAdapter);
+});
+

--- a/tests/unit/utilities/storage-support-test.js
+++ b/tests/unit/utilities/storage-support-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import StorageSupportUtility from '../../../storagekit/utilities/storage-support';
 import { module, test } from 'qunit';
+import wait from 'ember-test-helpers/wait';
 
-module('Unit | Utility | Storage Support', {});
+module('Unit | Utility | Storage Support');
 
 // Replace this with your real tests.
 test('it exists', function (assert) {
@@ -15,13 +16,16 @@ test('Correctly determines that there is localStorage support', function (assert
   Ember.run(() => {
     StorageSupportUtility.set('global', {
       localStorage: {
+        setItem() {},
         getItem() {},
-        setItem() {}
+        removeItem() {}
       }
     });
   });
 
-  assert.ok(StorageSupportUtility.has('localStorage'), 'Should determine that there is no storage support.');
+  return wait().then(() => {
+    assert.ok(StorageSupportUtility.has('localStorage'), 'Should determine that there is no storage support.');
+  });
 });
 
 test('Correctly determines that there is no localStorage support', function (assert) {
@@ -31,7 +35,9 @@ test('Correctly determines that there is no localStorage support', function (ass
     StorageSupportUtility.set('global', {});
   });
 
-  assert.notOk(StorageSupportUtility.has('localStorage'), 'Should determine that there is storage support.');
+  return wait().then(() => {
+    assert.notOk(StorageSupportUtility.has('localStorage'), 'Should determine that there is storage support.');
+  });
 });
 
 test('Correctly determines that there is sessionStorage support', function (assert) {
@@ -41,12 +47,15 @@ test('Correctly determines that there is sessionStorage support', function (asse
     StorageSupportUtility.set('global', {
       sessionStorage: {
         setItem() {},
-        getItem() {}
+        getItem() {},
+        removeItem() {}
       }
     });
   });
 
-  assert.ok(StorageSupportUtility.has('sessionStorage'), 'Should determine that there is no storage support.');
+  return wait().then(() => {
+    assert.ok(StorageSupportUtility.has('sessionStorage'), 'Should determine that there is no storage support.');
+  });
 });
 
 test('Correctly determines that there is no sessionStorage support', function (assert) {
@@ -56,7 +65,9 @@ test('Correctly determines that there is no sessionStorage support', function (a
     StorageSupportUtility.set('global', {});
   });
 
-  assert.notOk(StorageSupportUtility.has('sessionStorage'), 'Should determine that there is storage support.');
+  return wait().then(() => {
+    assert.notOk(StorageSupportUtility.has('sessionStorage'), 'Should determine that there is storage support.');
+  });
 });
 
 test('Recovers from error thrown during storage support check and interprets as lack of support', function (assert) {
@@ -66,7 +77,8 @@ test('Recovers from error thrown during storage support check and interprets as 
 
   // package does not support IE8 so we are ok to do this.
   Object.defineProperty(_global, 'localStorage', {
-    get: function () {
+    getItem: function () {
+      Ember.Logger.log('yo');
       throw Error;
     }
   });
@@ -75,7 +87,9 @@ test('Recovers from error thrown during storage support check and interprets as 
     StorageSupportUtility.set('global', _global);
   });
 
-  assert.notOk(StorageSupportUtility.get('localStorage'),
-    'Should determine that there is no localStorage support due to error.');
+  return wait().then(() => {
+    assert.notOk(StorageSupportUtility.get('localStorage'),
+      'Should determine that there is no localStorage support due to error.');
+  });
 });
 


### PR DESCRIPTION
Fixes issue where the instance storage failover wasn't kicking in properly. It also moves the storage check into the instance-initializers since initializers might happen as part of the fast boot process (i.e. we want the check to happen in the browser, not on the server).